### PR TITLE
Updated CLI Set URL

### DIFF
--- a/confetti-cli/Cargo.toml
+++ b/confetti-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "confetti_cli"
-version = "0.1.1"
+version = "0.1.2"
 description = "A simple command line interface to interact with a Confetti-Box instance."
 repository = "https://github.com/Dangoware/confetti-box"
 keywords = ["selfhost", "upload", "command_line"]

--- a/confetti-cli/Cargo.toml
+++ b/confetti-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "confetti_cli"
-version = "0.1.2"
+version = "0.1.1"
 description = "A simple command line interface to interact with a Confetti-Box instance."
 repository = "https://github.com/Dangoware/confetti-box"
 keywords = ["selfhost", "upload", "command_line"]

--- a/confetti-cli/src/main.rs
+++ b/confetti-cli/src/main.rs
@@ -53,7 +53,7 @@ enum Commands {
         /// Set the password for a server which requires login
         #[arg(short, long, required = false)]
         password: Option<String>,
-        /// Set the URL of the server to connect to
+        /// Set the URL of the server to connect to (assumes https://)
         #[arg(long, required = false)]
         url: Option<String>,
         /// Set the directory to download into by default
@@ -305,7 +305,12 @@ async fn main() -> Result<()> {
                     url
                 };
 
-                config.url = url.to_string();
+                if !url.starts_with("https://") || !url.starts_with("http://") {
+                    config.url = ("https://".to_owned() + url).to_string();
+                } else {
+                    config.url = url.to_string();
+                }
+
                 config.save().unwrap();
                 println!("URL set to \"{url}\"");
             }

--- a/confetti-cli/src/main.rs
+++ b/confetti-cli/src/main.rs
@@ -305,7 +305,7 @@ async fn main() -> Result<()> {
                     url
                 };
 
-                if !url.starts_with("https://") || !url.starts_with("http://") {
+                if !url.starts_with("https://") && !url.starts_with("http://") {
                     config.url = ("https://".to_owned() + url).to_string();
                 } else {
                     config.url = url.to_string();


### PR DESCRIPTION
imu set --url now will default to https:// if nothing is provided.

when i installed the CLI and ran the set command i put in the URL without https:// without thinking and i believe it would be a good addition to assume https:// if no prefix is provided.